### PR TITLE
incremental builds for both app and galleon

### DIFF
--- a/jboss/container/eap/cd/18.0/module.yaml
+++ b/jboss/container/eap/cd/18.0/module.yaml
@@ -3,8 +3,6 @@ name: jboss.container.eap.cd
 version: '18.0'
 description:  "JBoss Enterprise Application Platform CD 18"
 envs:
-    - name: MAVEN_LOCAL_REPO
-      value: "$HOME/.m2/repository"
     - name: "WILDFLY_VERSION"
       value: "17.0.0.Final"
 modules:

--- a/jboss/container/eap/s2i/galleon/artifacts/usr/local/s2i/save-artifacts
+++ b/jboss/container/eap/s2i/galleon/artifacts/usr/local/s2i/save-artifacts
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+. "${JBOSS_CONTAINER_WILDFLY_S2I_MODULE}/save-artifacts.sh"

--- a/jboss/container/eap/s2i/galleon/module.yaml
+++ b/jboss/container/eap/s2i/galleon/module.yaml
@@ -9,3 +9,8 @@ execute:
 modules:
   install:
   - name: jboss.container.wildfly.s2i.bash
+
+# required by save-artifacts
+packages:
+  install: 
+   - diffutils


### PR DESCRIPTION
- enable incremental builds.
- install diffutils package, required by galleon s2i save-artifacts.
- removed MAVEN_LOCAL_REPO set to initial value
