### PR TITLE
Remove the markers used by the legacy https script configuration

### DIFF
--- a/jboss/container/config/cd/18.0/added/standalone-openshift.xml
+++ b/jboss/container/config/cd/18.0/added/standalone-openshift.xml
@@ -51,7 +51,6 @@
                 </authorization>
             </security-realm>
             <security-realm name="ApplicationRealm">
-                <!-- ##SSL## -->
                 <authentication>
                     <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
                     <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
@@ -527,7 +526,6 @@
             <server name="default-server">
                 <ajp-listener name="ajp" socket-binding="ajp"/>
                 <http-listener name="default" socket-binding="http" redirect-socket="https" enable-http2="true"/>
-                <!-- ##HTTPS_CONNECTOR## -->
                 <host name="default-host" alias="localhost">
                     <location name="/" handler="welcome-content"/>
                     <!-- ##ACCESS_LOG_VALVE## -->


### PR DESCRIPTION
Remove the markers used by the legacy https script configuration