### PR TITLE
Remove security-domains and Elytron TLS related markers from standalone-openshift.xml

### DIFF
--- a/jboss/container/config/cd/18.0/added/standalone-openshift.xml
+++ b/jboss/container/config/cd/18.0/added/standalone-openshift.xml
@@ -207,7 +207,6 @@
             <default-missing-method-permissions-deny-access value="true"/>
             <statistics enabled="${wildfly.ejb3.statistics-enabled:${wildfly.statistics-enabled:false}}"/>
             <log-system-exceptions value="true"/>
-            <!-- ##EJB_APPLICATION_SECURITY_DOMAINS## -->
         </subsystem>
         <subsystem xmlns="urn:wildfly:elytron:7.0" final-providers="combined-providers" disallowed-providers="OracleUcrypto">
             <providers>
@@ -222,7 +221,6 @@
                 <file-audit-log name="local-audit" path="audit.log" relative-to="jboss.server.log.dir" format="JSON"/>
             </audit-logging>
             <security-domains>
-                <!-- ##ELYTRON_SECURITY_DOMAIN## -->
                 <security-domain name="ApplicationDomain" default-realm="ApplicationRealm" permission-mapper="default-permission-mapper">
                     <realm name="ApplicationRealm" role-decoder="groups-to-roles"/>
                     <realm name="local"/>
@@ -271,7 +269,6 @@
                 </permission-set>
             </permission-sets>
             <http>
-                <!-- ##HTTP_AUTHENTICATION_FACTORY## -->
                 <http-authentication-factory name="management-http-authentication" security-domain="ManagementDomain" http-server-mechanism-factory="global">
                     <mechanism-configuration>
                         <mechanism mechanism-name="DIGEST">
@@ -471,7 +468,6 @@
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
         <subsystem xmlns="urn:jboss:domain:security:2.0">
-            <!-- ##ELYTRON_INTEGRATION## -->
             <security-domains>
                 <security-domain name="other" cache-type="default">
                     <authentication>
@@ -494,7 +490,6 @@
                         <policy-module code="Delegating" flag="required"/>
                     </authorization>
                 </security-domain>
-                <!-- ##ADDITIONAL_SECURITY_DOMAINS## -->
             </security-domains>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:security-manager:1.0">
@@ -540,7 +535,6 @@
             <handlers>
                 <file name="welcome-content" path="${jboss.home.dir}/welcome-content"/>
             </handlers>
-            <!-- ##HTTP_APPLICATION_SECURITY_DOMAINS## -->
             <!-- ##HTTP_FILTERS_MARKER## -->
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:2.0" statistics-enabled="${wildfly.webservices.statistics-enabled:${wildfly.statistics-enabled:false}}">

--- a/jboss/container/config/cd/18.0/added/standalone-openshift.xml
+++ b/jboss/container/config/cd/18.0/added/standalone-openshift.xml
@@ -315,8 +315,6 @@
                 </mechanism-provider-filtering-sasl-server-factory>
                 <provider-sasl-server-factory name="global"/>
             </sasl>
-            <!-- ##TLS## -->
-            <!-- ##ELYTRON_TLS## -->
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:infinispan:8.0">
             <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server">


### PR DESCRIPTION
Supercedes #23 
Removes security-domains and TLS/HTTPS markers related to Elytron.sh and security-domains.sh scripts.

It relates to https://github.com/wildfly/wildfly-cekit-modules/pull/40