### PR TITLE
Add behave tests for port.sh and admin.sh

### DIFF
--- a/jboss/container/config/cd/18.0/added/standalone-openshift.xml
+++ b/jboss/container/config/cd/18.0/added/standalone-openshift.xml
@@ -74,7 +74,7 @@
             </logger>
         </audit-log>
         <management-interfaces>
-            <http-interface console-enabled="false"><!-- ##MGMT_IFACE_REALM## -->
+            <http-interface console-enabled="false">
                 <http-upgrade enabled="true"/>
                 <socket-binding http="management-http"/>
             </http-interface>

--- a/jboss/container/launch/cd/18.0/added/openshift-launch.sh
+++ b/jboss/container/launch/cd/18.0/added/openshift-launch.sh
@@ -3,11 +3,19 @@
 # Always start sourcing the launch script supplied by wildfly-cekit-modules
 source ${JBOSS_HOME}/bin/launch/launch.sh
 
+local management_port=""
+if [ -n "${PORT_OFFSET}" ]; then
+  management_port=$((9990 + PORT_OFFSET))
+fi
 
 # TERM signal handler
 function clean_shutdown() {
   log_error "*** JBossAS wrapper process ($$) received TERM signal ***"
-  $JBOSS_HOME/bin/jboss-cli.sh -c "shutdown --timeout=60"
+  if [ -z ${management_port} ]; then
+    $JBOSS_HOME/bin/jboss-cli.sh -c "shutdown --timeout=60"
+  else
+    $JBOSS_HOME/bin/jboss-cli.sh --commands="connect remote+http://localhost:${management_port},shutdown --timeout=60"
+  fi
   wait $!
 }
 

--- a/tests/features/7/admin.feature
+++ b/tests/features/7/admin.feature
@@ -1,0 +1,31 @@
+@jboss-eap-7 @jboss-eap-7-tech-preview
+Feature: EAP Openshift admin
+
+  Scenario: Standard configuration
+    When container is started with env
+       | variable       | value           |
+       | ADMIN_USERNAME | kabir           |
+       | ADMIN_PASSWORD | pass            |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value ManagementRealm on XPath //*[local-name()='http-interface']/@security-realm
+    And file /opt/eap/standalone/configuration/mgmt-users.properties should contain kabir
+
+
+  # This can't actually be done due to
+  #   [standalone@embedded /] /core-service=management/management-interface=http-interface:remove
+  #   {
+  #       "outcome" => "failed",
+  #       "failure-description" => "WFLYRMT0025: Can't remove [
+  #       (\"core-service\" => \"management\"),
+  #       (\"management-interface\" => \"http-interface\")
+  #   ] as JMX uses it as a remoting endpoint",
+  #       "rolled-back" => true
+  #   }
+  @ignore
+  Scenario: No http-interface
+    When container is started with command bash
+       | variable       | value           |
+       | ADMIN_USERNAME | kabir           |
+       | ADMIN_PASSWORD | pass            |
+    Then copy features/jboss-eap-modules/7/scripts/admin/remove-http-interface.cli to /tmp in container
+    And run /opt/eap/bin/jboss-cli.sh --file=/tmp/remove-http-interface.cli in container once
+    And file /tmp/boot.log should contain ERROR You have set environment variables to configure http-interface security-realm. Fix your configuration to contain the http-interface for this to happen.

--- a/tests/features/7/ports.feature
+++ b/tests/features/7/ports.feature
@@ -1,0 +1,31 @@
+@jboss-eap-7 @jboss-eap-7-tech-preview
+Feature: EAP Openshift port offset
+
+  Scenario: Zero port offset in base configuration
+    When container is started with env
+       | variable    | value           |
+       | PORT_OFFSET | 1000            |
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 1000 on XPath //*[local-name()='socket-binding-group']/@port-offset
+
+  Scenario: Port offset is different from non-zero value in base configuration
+    When container is started with command bash
+       | variable    | value           |
+       | PORT_OFFSET | 900             |
+    Then copy features/jboss-eap-modules/7/scripts/ports/port-offset-500.cli to /tmp in container
+    And run /opt/eap/bin/jboss-cli.sh --file=/tmp/port-offset-500.cli in container once
+    And run script -c /opt/eap/bin/openshift-launch.sh /tmp/boot.log in container and detach
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 900 on XPath //*[local-name()='socket-binding-group']/@port-offset
+    And file /tmp/boot.log should contain WARN You specified PORT_OFFSET=900 while the base configuration's value for the port-offset resolves to a different non-zero value. 900 will be used as the port offset.
+    # Short version of the string above to use as a sanity test in the next test
+    And file /tmp/boot.log should contain WARN You specified PORT_OFFSET
+
+  Scenario: Port offset is same as non-zero value in base configuration
+    When container is started with command bash
+       | variable    | value           |
+       | PORT_OFFSET | 500             |
+    Then copy features/jboss-eap-modules/7/scripts/ports/port-offset-500.cli to /tmp in container
+    And run /opt/eap/bin/jboss-cli.sh --file=/tmp/port-offset-500.cli in container once
+    And run script -c /opt/eap/bin/openshift-launch.sh /tmp/boot.log in container and detach
+    Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value 500 on XPath //*[local-name()='socket-binding-group']/@port-offset
+    And file /tmp/boot.log should not contain WARN You specified PORT_OFFSET
+

--- a/tests/features/7/scripts/admin/remove-http-interface.cli
+++ b/tests/features/7/scripts/admin/remove-http-interface.cli
@@ -1,0 +1,3 @@
+embed-server --timeout=30 --std-out=echo --server-config=standalone-openshift.xml
+/core-service=management/management-interface=http-interface:remove
+stop-embedded-server

--- a/tests/features/7/scripts/ports/port-offset-500.cli
+++ b/tests/features/7/scripts/ports/port-offset-500.cli
@@ -1,0 +1,3 @@
+embed-server --timeout=30 --std-out=echo --server-config=standalone-openshift.xml
+/socket-binding-group=standard-sockets:write-attribute(name=port-offset, value=500)
+stop-embedded-server


### PR DESCRIPTION
Also, I noticed that if PORT_OFFSET is used that Ctrl-C in the container does not stop the server.

Related PRs 
https://github.com/wildfly/temp-openshift-image/pull/17
https://github.com/wildfly/wildfly-cekit-modules/pull/43
