### PR TITLE
Interchange order between jgroups.sh and ha.sh, remove @wip annotation from scanner feature

### DIFF
--- a/jboss/container/launch/cd/18.0/added/launch/launch-config.sh
+++ b/jboss/container/launch/cd/18.0/added/launch/launch-config.sh
@@ -12,8 +12,10 @@ CONFIG_SCRIPT_CANDIDATES=(
   $JBOSS_HOME/bin/launch/datasource.sh
   $JBOSS_HOME/bin/launch/resource-adapter.sh
   $JBOSS_HOME/bin/launch/admin.sh
-  $JBOSS_HOME/bin/launch/ha.sh
+  # keep this order jgroups.sh and then ha.sh. 
+  # jgroups.sh needs to calculate where to insert a protocol, ha.sh could add one
   $JBOSS_HOME/bin/launch/jgroups.sh
+  $JBOSS_HOME/bin/launch/ha.sh
   $JBOSS_HOME/bin/launch/https.sh
   $JBOSS_HOME/bin/launch/elytron.sh
   $JBOSS_HOME/bin/launch/json_logging.sh

--- a/tests/features/7/deployment-scanner.feature
+++ b/tests/features/7/deployment-scanner.feature
@@ -1,4 +1,4 @@
-@jboss-eap-7 @jboss-eap-7-tech-preview @wip
+@jboss-eap-7 @jboss-eap-7-tech-preview
 Feature: EAP Openshift deployment-scanner tests
 
   Scenario: Server started with AUTO_DEPLOY_EXPLODED=true should work


### PR DESCRIPTION
Set jgroups.sh before than ha.sh. JGroups script by CLI calculates the position of pbcast.NAKACK2, ha.sh could add other protocols. There are some limitations about what we can do via CLI scripting, so, moving jgroups.sh before will ensure we are going to count from the original list of protocols available in the server config. If later ha.sh needs to calculate a position, we will need to communicate both scripts, for now, going by the simplest way. 