### PR TITLE
Add behave test to verify JGroups protocol order

### DIFF
--- a/jboss/container/launch/cd/18.0/added/launch/launch-config.sh
+++ b/jboss/container/launch/cd/18.0/added/launch/launch-config.sh
@@ -12,8 +12,10 @@ CONFIG_SCRIPT_CANDIDATES=(
   $JBOSS_HOME/bin/launch/datasource.sh
   $JBOSS_HOME/bin/launch/resource-adapter.sh
   $JBOSS_HOME/bin/launch/admin.sh
-  # keep this order jgroups.sh and then ha.sh. 
-  # jgroups.sh needs to calculate where to insert a protocol, ha.sh could add one
+  # Keep this order, jgroups.sh before ha.sh. jgroups.sh is the script which initializes the protocol list store
+  # used to share changes in the protocol list when a protocol is added either by ha.sh or by jgroups.sh.
+  # This protocol store is just a set of files under temporal directory. We need them to be able to share changes
+  # done by the ha.sh and jgroups.sh routines which are executed in subshells
   $JBOSS_HOME/bin/launch/jgroups.sh
   $JBOSS_HOME/bin/launch/ha.sh
   $JBOSS_HOME/bin/launch/https.sh

--- a/tests/features/7/CD/jgroups.feature
+++ b/tests/features/7/CD/jgroups.feature
@@ -16,9 +16,9 @@ Feature: Openshift EAP jgroups
      # https://issues.jboss.org/browse/CLOUD-1192
      # https://issues.jboss.org/browse/CLOUD-1196
      # Make sure the SYM_ENCRYPT protocol is specified before pbcast.NAKACK for udp stack
-     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK2 on XPath //*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/following-sibling::*[1]/@type
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK2 on XPath //*[local-name()="stack"][@name="udp"]/*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/following-sibling::*[1]/@type
      # Make sure the SYM_ENCRYPT protocol is specified before pbcast.NAKACK for tcp stack
-     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK2 on XPath //*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/following-sibling::*[1]/@type
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK2 on XPath //*[local-name()="stack"][@name="tcp"]/*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/following-sibling::*[1]/@type
 
   Scenario: Check jgroups encryption with missing keystore dir creates the location relative to the server dir
     When container is started with env
@@ -29,3 +29,29 @@ Feature: Openshift EAP jgroups
        | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
        | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
     Then XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jboss.server.config.dir on XPath //*[local-name()="key-store"][@name="keystore.jks"]/*[local-name()="file"]/@relative-to
+
+Scenario: Verify configuration and protocol positions jgroups-encrypt, DNS ping protocol and AUTH
+    When container is started with env
+       | variable                                     | value                                  |
+       | JGROUPS_ENCRYPT_SECRET                       | eap_jgroups_encrypt_secret             |
+       | JGROUPS_ENCRYPT_KEYSTORE_DIR                 | /etc/jgroups-encrypt-secret-volume     |
+       | JGROUPS_ENCRYPT_KEYSTORE                     | keystore.jks                           |
+       | JGROUPS_ENCRYPT_NAME                         | jboss                                  |
+       | JGROUPS_ENCRYPT_PASSWORD                     | mykeystorepass                         |
+       | JGROUPS_PING_PROTOCOL                        | dns.DNS_PING                           |
+       | JGROUPS_CLUSTER_PASSWORD                     | P@assw0rd                              |
+    Then container log should contain WFLYSRV0039:
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='protocol'][@type='dns.DNS_PING']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='encrypt-protocol'][@type='SYM_ENCRYPT']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 2 elements on XPath //*[local-name()='auth-protocol'][@type='AUTH']
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value keystore.jks on XPath //*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/@key-store
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value jboss on XPath //*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/@key-alias
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value mykeystorepass on XPath //*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/*[local-name()="key-credential-reference"]/@clear-text
+     # https://issues.jboss.org/browse/CLOUD-1192
+     # https://issues.jboss.org/browse/CLOUD-1196
+     # Make sure the SYM_ENCRYPT protocol is specified before pbcast.NAKACK for udp stack
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK2 on XPath //*[local-name()="stack"][@name="udp"]/*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/following-sibling::*[1]/@type
+     # Make sure the SYM_ENCRYPT protocol is specified before pbcast.NAKACK for tcp stack
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.NAKACK2 on XPath //*[local-name()="stack"][@name="tcp"]/*[local-name()="encrypt-protocol"][@type="SYM_ENCRYPT"]/following-sibling::*[1]/@type
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.GMS on XPath //*[local-name()="stack"][@name="udp"]/*[local-name()="auth-protocol"][@type="AUTH"]/following-sibling::*[1]/@type
+     And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should contain value pbcast.GMS on XPath //*[local-name()="stack"][@name="tcp"]/*[local-name()="auth-protocol"][@type="AUTH"]/following-sibling::*[1]/@type


### PR DESCRIPTION
Verifies that encrypt protocol is added before `pbcast.NAKACK` and authentication protocol before  `pbcast.GMS`

Requires https://github.com/wildfly/wildfly-cekit-modules/pull/108